### PR TITLE
Update Hebrew text alignment and typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,9 +33,9 @@
   <main>
     <section class="flow about">
       <h3 data-en="About Matan Retzer (M.Sc.)"
-          data-he="אודות מתן רצר (M.Sc.)"></h3>
+          data-he="אודות מתן רטצר (M.Sc.)"></h3>
       <p data-en="With a Master of Science and deep experience in artificial intelligence and machine learning, Matan Retzer partners with businesses to unlock new possibilities through GenAI innovation."
-         data-he="בעל תואר שני וניסיון מעמיק בבינה מלאכותית ולמידת מכונה, מתן רצר משתף פעולה עם עסקים לפתיחת אפשרויות חדשות בעזרת חדשנות GenAI."></p>
+         data-he="בעל תואר שני וניסיון מעמיק בבינה מלאכותית ולמידת מכונה, מתן רטצר משתף פעולה עם עסקים לפתיחת אפשרויות חדשות בעזרת חדשנות GenAI."></p>
       <ul>
         <li data-en="10+ years of experience in AI, ML, and data-driven business transformation"
             data-he="מעל 10 שנות ניסיון ב-AI, ML ושינוי עסקי מבוסס נתונים"></li>

--- a/style.css
+++ b/style.css
@@ -244,4 +244,5 @@ html[dir="rtl"] .service-card {
 }
 html[dir="rtl"] .contact-details {
   align-items: flex-end;
+  text-align: right;
 }


### PR DESCRIPTION
## Summary
- fix typo in Hebrew text: "רצר" -> "רטצר"
- align contact details right when page is in Hebrew

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68597d2069108324994e0084edf94bf8